### PR TITLE
Changed incorrect closing bracket ']' to curly brace '}' in  workload…

### DIFF
--- a/infra/workloadTier.bicep
+++ b/infra/workloadTier.bicep
@@ -151,7 +151,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
           id: nic.id
         }
       ]
-    ]
+    }
   }
 }
 


### PR DESCRIPTION
# Fix: Resolve BCP018 syntax error in workloadTier.bicep

## Problem
The Bicep file `infra/workloadTier.bicep` had a syntax error (BCP018) that prevented compilation:
```
Error BCP018: Expected the "}" character at this location.
```

This error blocked Azure deployment and prevented the template from being compiled to ARM JSON.

## Root Cause
In the VM resource definition, the `networkProfile` section had an incorrect closing bracket:

```bicep
networkProfile: {
  networkInterfaces: [
    {
      id: nic.id
    }
  ]
] // ❌ Incorrect closing bracket
```

The `networkProfile` object was closed with a square bracket `]` instead of a curly brace `}`, causing the Bicep parser to expect an additional closing brace at the end of the file.

## Solution
Fixed the syntax by replacing the incorrect closing bracket with the proper curly brace:

```bicep
networkProfile: {
  networkInterfaces: [
    {
      id: nic.id
    }
  ]
} // ✅ Correct closing brace
```

## Changes Made
- **File**: `infra/workloadTier.bicep`
- **Line**: 154
- **Change**: Replaced `]` with `}` to properly close the `networkProfile` object

## Verification
- ✅ `az bicep build` command now succeeds (exit code 0)
- ✅ File compiles to valid ARM template JSON
- ✅ All resource definitions have properly matched braces
- ✅ No blocking syntax errors remain

## Impact
- **Before**: Compilation failed with BCP018 error, blocking deployment
- **After**: Clean compilation with only minor linter warnings about unused parameters
- **Risk**: **Low** - Pure syntax fix with no functional changes to infrastructure resources

## Testing
```bash
az bicep build --file "infra/workloadTier.bicep" --stdout
```
This command now executes successfully and outputs valid ARM template JSON.

