### PR TITLE
Uncomment network dependency in main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -138,7 +138,7 @@ module webTier 'webTier.bicep' = {
     vmSize:         resolvedWebTierVmSize
   }
   dependsOn: [
-    //network 
+    network 
   ]
 }
 


### PR DESCRIPTION
prevent race condition when deploying the web tier. Network must be available before the VM NIC is deployed.