### PR TITLE
feat: implement SecurityControl tagging strategy across all resources

### DIFF
--- a/infra/appTier.bicep
+++ b/infra/appTier.bicep
@@ -34,6 +34,9 @@ param adminPassword string
 @description('VM size for app tier VMs')
 param vmSize string = 'Standard_B2s'
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // Reference the spoke2 VNet
 resource spoke2Vnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
   name: vnetName
@@ -43,6 +46,7 @@ resource spoke2Vnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
 resource appGwPip 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: '${appGwName}-pip'
   location: location
+  tags: tags
   sku: {
     name: 'Standard'
   }
@@ -62,6 +66,7 @@ var appGwSubnetRef = '${spoke2Vnet.id}/subnets/${appGwSubnetName}'
 resource nics 'Microsoft.Network/networkInterfaces@2021-05-01' = [for vm in vmNames: {
   name: '${vm}-nic'
   location: location
+  tags: tags
   properties: {
     ipConfigurations: [
       {
@@ -81,6 +86,7 @@ resource nics 'Microsoft.Network/networkInterfaces@2021-05-01' = [for vm in vmNa
 resource vms 'Microsoft.Compute/virtualMachines@2021-07-01' = [for (vm, i) in vmNames: {
   name: vm
   location: location
+  tags: tags
   properties: {
     hardwareProfile: {
       vmSize: vmSize
@@ -118,6 +124,7 @@ resource vms 'Microsoft.Compute/virtualMachines@2021-07-01' = [for (vm, i) in vm
 resource appServicePlan 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: '${appServiceName}-plan'
   location: location
+  tags: tags
   sku: {
     name: 'S1'
     tier: 'Standard'
@@ -127,6 +134,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2021-02-01' = {
 resource appService 'Microsoft.Web/sites@2021-02-01' = {
   name: '${appServiceName}-${uniqueString(resourceGroup().id)}'
   location: location
+  tags: tags
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
@@ -169,6 +177,7 @@ resource appServiceIPRestriction 'Microsoft.Web/sites/config@2021-02-01' = {
 resource appGateway 'Microsoft.Network/applicationGateways@2021-05-01' = {
   name: appGwName
   location: location
+  tags: tags
   properties: {
     sku: {
       name: 'WAF_v2'

--- a/infra/bastion.bicep
+++ b/infra/bastion.bicep
@@ -12,10 +12,14 @@ param bastionName string = 'hub-bastion'
 @description('Name for the Public IP to use')
 param pipName     string = 'hub-bastion-pip'
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // 1. Public IP for Bastion
 resource bastionPIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: pipName
   location: location
+  tags: tags
   sku: { name: 'Standard' }
   properties: {
     publicIPAllocationMethod: 'Static'
@@ -32,6 +36,7 @@ resource hubVnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
 resource bastionHost 'Microsoft.Network/bastionHosts@2021-05-01' = {
   name: bastionName
   location: location
+  tags: tags
   sku: { name: 'Standard' }
   properties: {
     ipConfigurations: [

--- a/infra/consumerPE.bicep
+++ b/infra/consumerPE.bicep
@@ -15,6 +15,8 @@ param location string = resourceGroup().location
 @description('Location of the private endpoint resource')
 param vnetName string = 'spoke2-vnet'
 
+@description('Tags to apply to resources')
+param tags object = {}
 
 // 1️⃣ Reference the consumer VNet & subnet
 resource spoke2Vnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
@@ -26,6 +28,7 @@ var consumerSubnetId = '${spoke2Vnet.id}/subnets/${consumerSubnetName}'
 resource pe 'Microsoft.Network/privateEndpoints@2021-05-01' = {
   name: peName
   location: location
+  tags: tags
   properties: {
     subnet: { id: consumerSubnetId }
     privateLinkServiceConnections: [

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -64,6 +64,11 @@ var resolvedAppTierVmSize = !empty(appTierVmSize) ? appTierVmSize : defaultVmSiz
 var resolvedWorkloadTierVmSize = !empty(workloadTierVmSize) ? workloadTierVmSize : defaultVmSize
 var resolvedVmssVmSize = !empty(vmssVmSize) ? vmssVmSize : defaultVmSize
 
+// Standard tag for trainer demos
+var standardTags = {
+  SecurityControl: 'Ignore'
+}
+
 var hubVnetName = 'hub-vnet'
 var spoke1VnetName = 'spoke1-vnet'
 var spoke2VnetName = 'spoke2-vnet'
@@ -81,6 +86,7 @@ module network 'network.bicep' = {
     spoke1VnetName: spoke1VnetName
     spoke2VnetName: spoke2VnetName
     workloadVnetName: workloadVnetName
+    tags: standardTags
   }
 }
 
@@ -91,6 +97,7 @@ module bastion 'bastion.bicep' = if (deployBastion) {
     vnetName:      hubVnetName
     bastionName:   'hub-bastion'
     pipName:       'hub-bastion-pip'
+    tags: standardTags
   }
   dependsOn: [
     network 
@@ -104,6 +111,7 @@ module vpnGateway 'vpnGateway.bicep' = if (deployVpnGateway) {
     vnetName: hubVnetName
     gatewayPip: 'hub-vpn-pip'
     vpnGatewayName: 'hub-vpn-gateway'
+    tags: standardTags
   }
   dependsOn: [
     network  
@@ -136,6 +144,7 @@ module webTier 'webTier.bicep' = {
     adminUsername:  adminUsername
     adminPassword:  adminPassword
     vmSize:         resolvedWebTierVmSize
+    tags: standardTags
   }
   dependsOn: [
     network 
@@ -156,6 +165,7 @@ module appTier 'appTier.bicep' = {
     adminUsername: adminUsername
     adminPassword: adminPassword
     vmSize: resolvedAppTierVmSize
+    tags: standardTags
   }
   dependsOn: [
     network 
@@ -173,6 +183,7 @@ module workloadTier 'workloadTier.bicep' = {
     adminUsername: adminUsername
     adminPassword: adminPassword
     vmSize: resolvedWorkloadTierVmSize
+    tags: standardTags
   }
   dependsOn: [
     network 
@@ -187,6 +198,7 @@ module consumerPe 'consumerPE.bicep' = {
     consumerSubnetName: 'default'
     peName:             'workload-pe'
     plsName:            'workload-pls'
+    tags: standardTags
   }
   dependsOn: [
     workloadTier
@@ -204,6 +216,7 @@ module shared 'sharedServices.bicep' = {
     deployKeyVault: deployKeyVault
     adminObjectId: adminObjectId
     enableCmkForStorage: enableCmkForStorage
+    tags: standardTags
   }
   dependsOn: [
     workloadTier
@@ -233,6 +246,7 @@ module vmss 'vmss.bicep' = {
     instanceCount:  2
     adminUsername:  adminUsername
     adminPassword: adminPassword
+    tags: standardTags
   }
   dependsOn: [
     network

--- a/infra/network.bicep
+++ b/infra/network.bicep
@@ -26,6 +26,9 @@ param spoke2VnetName string
 @description('Name of workload virtual network (private-link)')
 param workloadVnetName string
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // Use the common network address prefixes
 var hubAddressPrefix      = common.outputs.networkAddressSpace.hub
 var spoke1AddressPrefix   = common.outputs.networkAddressSpace.spoke1  
@@ -40,19 +43,18 @@ var gatewaySubnetPrefix = common.outputs.subnets.gateway.prefix
 var hubMgmtSubnetName = common.outputs.subnets.management.name
 var hubMgmtSubnetPrefix = common.outputs.subnets.management.prefix
 
-// Apply common tags to all resources - fixed to use object literal directly
-var tags = {
+// Apply common tags to all resources - union with passed tags
+var resourceTags = union(tags, {
   environment: 'demo'
   projectName: 'az104'
   CostControl: 'ignore'
-  SecurityControl: 'ignore'
-}
+})
 
 // Create Hub VNet
 resource hubVnet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
   name: hubVnetName
   location: hublocation
-  tags: tags
+  tags: resourceTags
   properties: {
     addressSpace: {
       addressPrefixes: [ hubAddressPrefix ]
@@ -84,6 +86,7 @@ resource hubVnet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
 resource spoke1Nsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: '${spoke1VnetName}-nsg'
   location: spoke1location
+  tags: resourceTags
   properties: {
     securityRules: [
       {
@@ -107,6 +110,7 @@ resource spoke1Nsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
 resource spoke2Nsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: '${spoke2VnetName}-nsg'
   location: spoke2location
+  tags: resourceTags
   properties: {
     securityRules: [
       {
@@ -156,6 +160,7 @@ resource spoke2Nsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
 resource workloadNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: '${workloadVnetName}-nsg'
   location: workloadlocation
+  tags: resourceTags
   properties: {
     securityRules: [
       {
@@ -179,6 +184,7 @@ resource workloadNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
 resource appGwNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: '${spoke2VnetName}-appgw-nsg'
   location: spoke2location
+  tags: resourceTags
   properties: {
     securityRules: [
       {
@@ -240,7 +246,8 @@ resource appGwNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
 // Create Route Table with custom route to Virtual Appliance
 resource customRouteTable 'Microsoft.Network/routeTables@2021-05-01' = {
   name: 'custom-route-table'
-  location: spoke2location 
+  location: spoke2location
+  tags: resourceTags
   properties: {
     disableBgpRoutePropagation: false
     routes: [

--- a/infra/sharedServices.bicep
+++ b/infra/sharedServices.bicep
@@ -180,6 +180,7 @@ module storageKeyAccess 'modules/keyvaultAccess.bicep' = if (deployKeyVault && e
   }
   dependsOn: [
     keyVaultResource
+    storageAccount
   ]
 }
 

--- a/infra/vmss.bicep
+++ b/infra/vmss.bicep
@@ -22,6 +22,9 @@ param adminUsername string = 'azureuser'
 @description('Admin password for VM')
 param adminPassword string
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // Reference existing VNet and Subnet
 resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
   name: vnetName
@@ -36,6 +39,7 @@ var vmssName = 'vmssaz104'
 resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-07-01' = {
   name: vmssName
   location: location
+  tags: tags
   sku: {
     name: vmSku
     tier: 'Standard'

--- a/infra/vpnGateway.bicep
+++ b/infra/vpnGateway.bicep
@@ -13,10 +13,14 @@ param gatewayPip    string = 'hub-vpn-pip'
 @description('Name of the VPN gateway')
 param vpnGatewayName string = 'hub-vpn-gateway'
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // 1️⃣ Create a Public IP for the VPN Gateway
 resource publicIp 'Microsoft.Network/publicIPAddresses@2021-08-01' = {
   name: gatewayPip
   location: location
+  tags: tags
   sku: {
     name: 'Standard'
   }
@@ -34,6 +38,7 @@ resource hubVnet 'Microsoft.Network/virtualNetworks@2021-08-01' existing = {
 resource vpnGateway 'Microsoft.Network/virtualNetworkGateways@2021-08-01' = {
   name: vpnGatewayName
   location: location
+  tags: tags
 
   properties: {
     vpnType: 'RouteBased'

--- a/infra/workloadTier.bicep
+++ b/infra/workloadTier.bicep
@@ -26,6 +26,9 @@ param adminPassword string
 @description('VM size for workload tier VM')
 param vmSize string = 'Standard_B2ms'
 
+@description('Tags to apply to resources')
+param tags object = {}
+
 // Reference the workload VNet
 resource workloadVnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
   name: vnetName
@@ -38,6 +41,7 @@ var subnetRef = '${workloadVnet.id}/subnets/${subnetName}'
 resource privateLB 'Microsoft.Network/loadBalancers@2021-05-01' = {
   name: lbName
   location: location
+  tags: tags
   sku: {
     name: 'Standard'
   }
@@ -98,6 +102,7 @@ resource privateLB 'Microsoft.Network/loadBalancers@2021-05-01' = {
 resource nic 'Microsoft.Network/networkInterfaces@2021-05-01' = {
   name: '${vmName}-nic'
   location: location
+  tags: tags
   properties: {
     ipConfigurations: [
       {
@@ -122,6 +127,7 @@ resource nic 'Microsoft.Network/networkInterfaces@2021-05-01' = {
 resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
   name: vmName
   location: location
+  tags: tags
   properties: {
     hardwareProfile: {
       vmSize: vmSize
@@ -159,6 +165,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
 resource privateLinkService 'Microsoft.Network/privateLinkServices@2021-05-01' = {
   name: 'workload-pls'
   location: location
+  tags: tags
   properties: {
     enableProxyProtocol: false
     loadBalancerFrontendIpConfigurations: [


### PR DESCRIPTION
As are preventative measure from future changes in MTT's subscriptions, it is being recommended to add SecurityControl tagging.  Staying up to date with policy is also a recommendation, as this template is, but to allow, MTTs to deploy even after a policy change is advantageous to a course.

- Add standardTags variable with SecurityControl: 'Ignore' to main.bicep
- Pass tags parameter to all modules for consistent resource tagging
- Use union strategy for modules with existing tags (webTier, sharedServices, network)
- Add direct tagging for resources without existing tags (bastion, vpnGateway, appTier, workloadTier, vmss, consumerPE)
- Update all applicable Azure resources to support trainer demo requirements